### PR TITLE
Fix stats and add options

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,12 @@ var instance = aedes()
 stats(aedes)
 ```
 
+## Options
+
+An object containing options can be passed in as the second argument to `stats`.
+
+* `interval`: ms to wait between publishing stats (defaults to 1000)
+
 ## Topics and Stats published
 
 * `$SYS/{ID}/uptime`

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "tape": "^4.6.0"
   },
   "dependencies": {
-    "moment": "^2.13.0",
     "moving-average": "^0.1.1",
     "mqtt": "^2.4.0"
   }

--- a/stats.js
+++ b/stats.js
@@ -34,7 +34,8 @@ function wire (aedesInstance) {
     maxConnectedClients: 0,
     connectedClients: 0,
     publishedMessages: 0,
-    started: new Date()
+    started: new Date(),
+    time: new Date()
   }
 
   function doPub (topic, value) {
@@ -47,9 +48,10 @@ function wire (aedesInstance) {
 
   function iterate () {
     var stats = aedesInstance.stats
+    stats.time = new Date()
     var mem = process.memoryUsage()
     doPub('uptime', moments.from(Date.now(), true))
-    doPub('time', aedesInstance.stats.started.toISOString())
+    doPub('time', aedesInstance.stats.time.toISOString())
     doPub('clients/total', stats.connectedClients)
     doPub('clients/maximum', stats.maxConnectedClients)
     doPub('messages/publish/sent', stats.publishedMessages)

--- a/stats.js
+++ b/stats.js
@@ -1,7 +1,5 @@
 'use strict'
 
-var moment = require('moment')
-
 function client () {
   this.stats.connectedClients++
   if (this.stats.connectedClients > this.stats.maxConnectedClients) {
@@ -42,15 +40,14 @@ function wire (aedesInstance) {
     aedesInstance.publish({topic: '$SYS/' + aedesInstance.id + '/' + topic, payload: '' + value})
   }
 
-  var moments = moment(new Date())
-
   var timer = setInterval(iterate, 1 * 1000)
 
   function iterate () {
     var stats = aedesInstance.stats
     stats.time = new Date()
+    var uptime = Math.round((stats.time - stats.started) / 1000)
     var mem = process.memoryUsage()
-    doPub('uptime', moments.from(Date.now(), true))
+    doPub('uptime', uptime)
     doPub('time', aedesInstance.stats.time.toISOString())
     doPub('clients/total', stats.connectedClients)
     doPub('clients/maximum', stats.maxConnectedClients)

--- a/stats.js
+++ b/stats.js
@@ -23,10 +23,12 @@ var aedesEvents = [
   publish
 ]
 
-function wire (aedesInstance) {
+function wire (aedesInstance, options) {
   if (!aedesInstance) {
     throw new Error('Need to pass an instance of aedes to enable stats')
   }
+
+  options = options || {}
 
   aedesInstance.stats = {
     maxConnectedClients: 0,
@@ -40,7 +42,7 @@ function wire (aedesInstance) {
     aedesInstance.publish({topic: '$SYS/' + aedesInstance.id + '/' + topic, payload: '' + value})
   }
 
-  var timer = setInterval(iterate, 1 * 1000)
+  var timer = setInterval(iterate, options.interval || (1 * 1000))
 
   function iterate () {
     var stats = aedesInstance.stats

--- a/test.js
+++ b/test.js
@@ -4,7 +4,6 @@ var test = require('tape').test
 var mqtt = require('mqtt')
 var aedes = require('aedes')
 var net = require('net')
-var moment = require('moment')
 var port = 1889
 
 test('Connect a client and subscribe to get total number of clients', function (t) {
@@ -126,8 +125,8 @@ test('Connect a client and subscribe to get broker up-time', function (t) {
   subscriber.subscribe('$SYS/+/uptime')
 
   subscriber.on('message', function (topic, message) {
-    var moments = moment(instance.started)
-    t.equal(moments.from(Date.now(), true).toString(), message.toString(), 'Broker uptime')
+    var seconds = Math.round((instance.stats.time - instance.stats.started) / 1000)
+    t.equal(seconds.toString(), message.toString(), 'Broker uptime')
     subscriber.end()
     instance.close()
     server.close()

--- a/test.js
+++ b/test.js
@@ -98,7 +98,7 @@ test('Connect a client and subscribe to get current broker time', function (t) {
   subscriber.subscribe('$SYS/+/time')
 
   subscriber.on('message', function (topic, message) {
-    t.equal(instance.stats.started.toISOString(), message.toString(), 'current broker time')
+    t.equal(instance.stats.time.toISOString(), message.toString(), 'current broker time')
     subscriber.end()
     additionalClient.end()
     instance.close()


### PR DESCRIPTION
I added an option to specify a custom interval. The default is still 1 second (1000 ms).

I also fixed the time and uptime stats.

The `time` stat was always the time the broker started. The "docs" here say that `time` should be the current broker time:

https://github.com/mqtt/mqtt.github.io/wiki/SYS-Topics

The `uptime` stat was formatted with `moment` so it was easy to read, but hard to parse. The above docs say it's supposed to be in seconds so I changed it to consistently be seconds. Without the formatting, I was able to drop `moment` as a dependency.

Tests pass and the API is backwards compatible, but I think changing the stats make this a breaking change.